### PR TITLE
Add AttachThreadInput hack

### DIFF
--- a/NotificationMaster.sln
+++ b/NotificationMaster.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31612.314
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31727.386
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotificationMaster", "NotificationMaster\NotificationMaster.csproj", "{27E0D6AC-610F-4E65-8336-651803FDBB3B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NotificationMaster", "NotificationMaster\NotificationMaster.csproj", "{27E0D6AC-610F-4E65-8336-651803FDBB3B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,8 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{27E0D6AC-610F-4E65-8336-651803FDBB3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{27E0D6AC-610F-4E65-8336-651803FDBB3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27E0D6AC-610F-4E65-8336-651803FDBB3B}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{27E0D6AC-610F-4E65-8336-651803FDBB3B}.Debug|Any CPU.Build.0 = Debug|x64
 		{27E0D6AC-610F-4E65-8336-651803FDBB3B}.Release|Any CPU.ActiveCfg = Release|x64
 		{27E0D6AC-610F-4E65-8336-651803FDBB3B}.Release|Any CPU.Build.0 = Release|x64
 	EndGlobalSection


### PR DESCRIPTION
Since `SetForegroundWindow` has to follow a lot of rules in order to function (which is likely not the case when you are alt-tabbed and browsing/on discord)
have to resort to some bad behaviour to get our window foregrounded