### PR TITLE
Implementing PartyFinder notificator

### DIFF
--- a/NotificationMaster/Configuration/Configuration.cs
+++ b/NotificationMaster/Configuration/Configuration.cs
@@ -87,6 +87,14 @@ namespace NotificationMaster
         public bool mobPulled_ChatMessage = true;
         public bool mobPulled_Toast = true;
 
+        public bool partyFinder_Enable = false;
+        public bool partyFinder_OnlyWhenFilled = false;
+        public bool partyFinder_Delisted = false;
+        public bool partyFinder_ShowToastNotification = true;
+        public bool partyFinder_FlashTrayIcon = true;
+        public bool partyFinder_AutoActivateWindow = false;
+        public SoundSettings partyFinder_SoundSettings = new();
+
         public void Initialize(DalamudPluginInterface pluginInterface)
         {
             this.pluginInterface = pluginInterface;

--- a/NotificationMaster/Gui/ConfigGui.cs
+++ b/NotificationMaster/Gui/ConfigGui.cs
@@ -76,6 +76,7 @@ namespace NotificationMaster
                         DrawTab("Connection error", DrawLoginErrorConfig, p.cfg.loginError_Enable);
                         DrawTab("Approaching map flag", DrawMapFlagConfig, p.cfg.mapFlag_Enable);
                         DrawTab("Mob pulled", DrawMobPulledConfig, p.cfg.mobPulled_Enable);
+                        DrawTab("PartyFinder", DrawPartyFinderConfig, p.cfg.partyFinder_Enable);
                         KoFiButton.RightTransparentTab();
                         ImGui.EndTabBar();
                     }

--- a/NotificationMaster/Gui/Notificators/PartyFinderGui.cs
+++ b/NotificationMaster/Gui/Notificators/PartyFinderGui.cs
@@ -1,0 +1,57 @@
+﻿using ImGuiNET;
+using NotificationMaster.Notificators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NotificationMaster
+{
+    partial class ConfigGui
+    {
+        internal void DrawPartyFinderConfig()
+        {
+            if (ImGui.Checkbox("Enable", ref p.cfg.partyFinder_Enable))
+            {
+                PartyFinder.Setup(p.cfg.partyFinder_Enable, p);
+            }
+            if (p.cfg.partyFinder_Enable)
+            {
+                ImGui.Checkbox("Only when the party fills up", ref p.cfg.partyFinder_OnlyWhenFilled);
+                ImGui.Checkbox("Notify if the party is delisted", ref p.cfg.partyFinder_Delisted);
+
+                if (p.cfg.partyFinder_OnlyWhenFilled)
+                {
+                    if (p.cfg.partyFinder_Delisted)
+                    {
+                        ImGui.Text("When the party fills or is delisted");
+                    }
+                    else
+                    {
+                        ImGui.Text("When the party fills");
+                    }
+                }
+                else
+                {
+                    if (p.cfg.partyFinder_Delisted)
+                    {
+                        ImGui.Text("When someone joins or leaves the party, or the party is delisted");
+                    }
+                    else
+                    {
+                        ImGui.Text("When someone joins or leaves the party");
+                    }
+                }
+
+                ImGui.Text("do the following if FFXIV is running in background: ");
+
+                ImGui.Checkbox("Show tray notification", ref p.cfg.partyFinder_ShowToastNotification);
+                ImGui.Checkbox("Flash taskbar icon", ref p.cfg.partyFinder_FlashTrayIcon);
+                ImGui.Checkbox("Bring FFXIV to foreground", ref p.cfg.partyFinder_AutoActivateWindow);
+                ForegroundWarning(p.cfg.partyFinder_AutoActivateWindow);
+                DrawSoundSettings(ref p.cfg.partyFinder_SoundSettings);
+            }
+        }
+    }
+}

--- a/NotificationMaster/NotificationMaster.cs
+++ b/NotificationMaster/NotificationMaster.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 using NotificationMasterAPI;
+using NotificationMaster.Notificators;
 
 namespace NotificationMaster
 {
@@ -27,6 +28,7 @@ namespace NotificationMaster
         internal LoginError loginError = null;
         internal ApproachingMapFlag mapFlag = null;
         internal MobPulled mobPulled = null;
+        internal PartyFinder partyFinder = null;
 
         internal HttpMaster httpMaster;
         public ThreadUpdateActivatedState ThreadUpdActivated;
@@ -61,6 +63,8 @@ namespace NotificationMaster
             if (cfg.loginError_Enable) LoginError.Setup(true, this);
             if (cfg.mapFlag_Enable) ApproachingMapFlag.Setup(true, this);
             if (cfg.mobPulled_Enable) MobPulled.Setup(true, this);
+            if (cfg.partyFinder_Enable) PartyFinder.Setup(true, this);
+
             if (Svc.PluginInterface.Reason == PluginLoadReason.Installer)
             {
                 configGui.open = true;

--- a/NotificationMaster/Notificators/PartyFinder.cs
+++ b/NotificationMaster/Notificators/PartyFinder.cs
@@ -62,7 +62,7 @@ namespace NotificationMaster.Notificators
                 return;
             }
 
-            if (oldCount != -1 && memberCount > 1 && oldCount != memberCount)
+            if (oldCount != -1 && memberCount > 0 && oldCount != memberCount)
             {
                 if (oldCount > memberCount)
                 {

--- a/NotificationMaster/Notificators/PartyFinder.cs
+++ b/NotificationMaster/Notificators/PartyFinder.cs
@@ -1,0 +1,144 @@
+﻿using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Hooking;
+using Dalamud.Utility.Signatures;
+using ECommons.Logging;
+using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using System;
+
+namespace NotificationMaster.Notificators
+{
+    internal unsafe class PartyFinder : IDisposable
+    {
+        private NotificationMaster p;
+        private int memberCount = -1;
+
+        private delegate void ShowLogMessageDelegate(RaptureLogModule* module, uint id);
+        [Signature(
+            "E8 ?? ?? ?? ?? 44 03 FB ?? ?? ?? ?? ?? ?? ?? ??",
+            DetourName = nameof(ShowLogMessageDetour)
+        )]
+        private Hook<ShowLogMessageDelegate> ShowLogMessageHook { get; init; }
+
+
+        public void Dispose()
+        {
+            Svc.Framework.Update -= Tick;
+
+            ShowLogMessageHook?.Disable();
+            ShowLogMessageHook?.Dispose();
+        }
+
+        public PartyFinder(NotificationMaster plugin)
+        {
+            this.p = plugin;
+            Svc.Framework.Update += Tick;
+
+            Svc.Hook.InitializeFromAttributes(this);
+            ShowLogMessageHook.Enable();
+        }
+
+        void Tick(object _)
+        {
+            AddonPartyList* addon = (AddonPartyList*)Svc.GameGui.GetAddonByName("_PartyList", 1);
+            if (addon == null)
+            {
+                return;
+            }
+
+            int oldCount = memberCount;
+            memberCount = addon->MemberCount;
+
+            if (oldCount > 1 && memberCount == 1)
+            {
+                Notify("Party disbanded.");
+                return;
+            }
+
+            if (!Svc.Condition[ConditionFlag.UsingPartyFinder] ||
+                p.cfg.partyFinder_OnlyWhenFilled)
+            {
+                return;
+            }
+
+            if (oldCount != -1 && memberCount > 1 && oldCount != memberCount)
+            {
+                if (oldCount > memberCount)
+                {
+                    Notify("A player has left the party.");
+                }
+                else
+                {
+                    Notify("A player has joined the party.");
+                }
+            }
+        }
+
+        private void ShowLogMessageDetour(RaptureLogModule* module, uint id)
+        {
+            ShowLogMessageHook.Original(module, id);
+
+            if (p.cfg.partyFinder_Delisted && (id == 981 || id == 982 || id == 985 || id == 986 || id == 7448))
+            {
+                Notify("Party recruitment ended.");
+            }
+            else if (id == 983 || id == 984 || id == 7451 || id == 7452)
+            {
+                Notify("Party recruitment ended. All places have been filled.");
+            }
+        }
+
+        private void Notify(string message)
+        {
+            if (p.cfg.partyFinder_FlashTrayIcon)
+            {
+                Native.Impl.FlashWindow();
+            }
+
+            if (p.cfg.partyFinder_AutoActivateWindow)
+            {
+                Native.Impl.Activate();
+            }
+
+            if (p.cfg.partyFinder_ShowToastNotification)
+            {
+                TrayIconManager.ShowToast(message);
+            }
+
+            if (p.cfg.partyFinder_SoundSettings.PlaySound)
+            {
+                p.audioPlayer.Play(p.cfg.partyFinder_SoundSettings);
+            }
+        }
+
+        internal static void Setup(bool enable, NotificationMaster p)
+        {
+            if (enable)
+            {
+                if (p.partyFinder == null)
+                {
+                    p.partyFinder = new PartyFinder(p);
+                    PluginLog.Information("Enabling partyFinder module");
+                }
+                else
+                {
+                    PluginLog.Information("partyFinder module already enabled");
+                }
+            }
+            else
+            {
+                if (p.partyFinder != null)
+                {
+                    p.partyFinder.Dispose();
+                    p.partyFinder = null;
+                    PluginLog.Information("Disabling partyFinder module");
+                }
+                else
+                {
+                    PluginLog.Information("partyFinder module already disabled");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Suggestion from: https://github.com/NightmareXIV/NotificationMaster/issues/8

Adds a new type of notification for PartyFinder events:

![image](https://github.com/NightmareXIV/NotificationMaster/assets/6404136/acc334a7-2388-4f01-8403-6cacf707c3b4)

Features:
* Sends a notification if the party fills
* Optionally sends a notification if a player joins or leaves the party 
* Optionally sends a notification if the party is delisted. This can be caused by different things and some of these events will only reach the party leader.

Notes:
In my experience the easiest and most reliable way to know the party size is through the in-game party list addon. This way there's no need to have cross world parties specific checks or anything like that. I used to detect changes on the party member count.
Also there's a hook to `RaptureLogModule`'s `ShowLogMessage` to detect when the party fills or is delisted.